### PR TITLE
 Added support for hall effect based potentiometers.

### DIFF
--- a/src/rsi.potentiometer.h
+++ b/src/rsi.potentiometer.h
@@ -12,14 +12,16 @@ public:
     PotentiometerRead(unsigned int pin, unsigned int minValue = 0, unsigned int maxValue = 1023, unsigned int confidenceLevel = 20, bool reverseDirection = false);
     unsigned int readValue();
     void reset();
-    void updateValue();
+    virtual void updateValue();
     unsigned int getMinValue();
     unsigned int getMaxValue();
     void setMinValue(unsigned int minValue);
     void setMaxValue(unsigned int maxValue);
     void setConfidenceLevel(unsigned int confidenceLevel);
     int checkForChange();
-private:
+
+    
+protected:
     unsigned int reading;
     unsigned int confidenceLevel;
     unsigned int pin;
@@ -31,4 +33,22 @@ private:
     bool reverseDirection = false;
     unsigned int cfc;
 };
+
+/**
+ * Polymorphic class for reading a potentiometer using a Hall Effect sensor.
+ * @extends PotentiometerRead
+*/
+class HallEffectPotentiometerRead : public PotentiometerRead {
+public:
+    HallEffectPotentiometerRead(unsigned int pin, unsigned int minValue = 0, unsigned int maxValue = 1023, unsigned int confidenceLevel = 20, int directionalDeltaConfidence = 3, bool reverseDirection = false);
+    void updateValue() override;
+    void setDirectionalDeltaConfidence(int directionalDeltaConfidence);
+    int getDirectionalDeltaConfidence();
+
+private:
+    int directionalDeltaConfidence;
+    unsigned int hallDirection;
+    int hallDirCount;
+};
+
 #endif


### PR DESCRIPTION
This extension programmably forces hall effect based potentiometers to act like normal ones, your min and max value set upper and lowwer bounds for the potentiometor.
Note: Do to the bounds and readout scaling this is not intended to give you realistic reading of the potentiometor. Instead it gives you a readout based on relative movement of the dial.